### PR TITLE
use git.config for development branch, default to develop

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -193,8 +193,10 @@ export namespace flow.feature {
         await requireNoSuchBranch(new_branch, {
             message: `The feature "${feature_name}" already exists`
         });
-        const local_develop = git.BranchRef.fromName('develop');
-        const remote_develop = git.BranchRef.fromName('origin/develop');
+        const develop_name = await git.config.get('gitflow.branch.develop');
+      
+        const local_develop = git.BranchRef.fromName(develop_name || 'develop');
+        const remote_develop = git.BranchRef.fromName(`origin/${develop_name || 'develop'}`);
         const local_ref = await local_develop.ref();
         if (await remote_develop.exists()) {
             await git.requireEqual(local_develop, remote_develop, true);


### PR DESCRIPTION
During feature start process, 'develop' was hardcoded in for the development branch name, updated this to use git.config to get the name of the development branch, default to 'develop' if null