### PR TITLE
Fixing typo in symbolic-ref path.

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -120,7 +120,7 @@ export namespace flow {
             'rev-parse', '--quiet', '--verify', 'HEAD'
           ])).retc) {
       await cmd.executeRequired(
-          git.info.path, ['symbolic-ref', 'HEAD', `refs/head/${master.name}`]);
+          git.info.path, ['symbolic-ref', 'HEAD', `refs/heads/${master.name}`]);
       await cmd.executeRequired(
           git.info.path,
           ['commit', '--allow-empty', '--quiet', '-m', 'Initial commit']);


### PR DESCRIPTION
This typo causes initialization of gitflow to fail on newly initialized repositories.

Fixes a cause of https://github.com/vector-of-bool/vscode-gitflow/issues/10