### PR TITLE
Change to actually use tag_prefix

### DIFF
--- a/src/flow.ts
+++ b/src/flow.ts
@@ -468,7 +468,10 @@ export namespace flow.release {
 
       // Create a tag for the release
       const tag_prefix = await tagPrefix();
-      const release_name = branch.name.substr(rel_prefix.length);
+      let release_name = branch.name.substr(rel_prefix.length);
+      if (tag_prefix) {
+        release_name = tag_prefix.concat(release_name);
+      }
       pr.report({message: `Tagging ${master}: ${release_name}...`});
       await cmd.executeRequired(
           git.info.path, ['tag', '-m', tag_message, release_name, master.name]);

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -467,11 +467,9 @@ export namespace flow.release {
       }
 
       // Create a tag for the release
-      const tag_prefix = await tagPrefix();
-      let release_name = branch.name.substr(rel_prefix.length);
-      if (tag_prefix) {
-        release_name = tag_prefix.concat(release_name);
-      }
+      const tag_prefix = await tagPrefix() || '';
+      const release_name = tag_prefix.concat(branch.name.substr(
+        rel_prefix.length));
       pr.report({message: `Tagging ${master}: ${release_name}...`});
       await cmd.executeRequired(
           git.info.path, ['tag', '-m', tag_message, release_name, master.name]);


### PR DESCRIPTION
At the moment tag_prefix is not actually used when creating a tag for the release.

This fixes it by changing const release_name to let release_name to be able to modify it if
tag_prefix is set (using concat).