### PR TITLE
Try to guess version numbers for new hotfixes and releases

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,8 +60,11 @@ async function setup(disposables: vscode.Disposable[]) {
         async function() {
           await runWrapped(flow.requireFlowEnabled);
           await runWrapped(flow.release.precheck);
+          const guessed_version = await runWrapped(
+            flow.release.guess_new_version) || '';
           const name = await vscode.window.showInputBox({
-            placeHolder: '1.6.2',
+            placeHolder: guessed_version,
+            value: guessed_version,
             prompt: 'The name of the release',
           });
           if (!name) return;
@@ -76,7 +79,11 @@ async function setup(disposables: vscode.Disposable[]) {
         'gitflow.hotfixStart',
         async function() {
           await runWrapped(flow.requireFlowEnabled);
+          const guessed_version = await runWrapped(
+            flow.hotfix.guess_new_version) || '';
           const name = await vscode.window.showInputBox({
+            placeHolder: guessed_version,
+            value: guessed_version,
             prompt: 'The name of the hotfix version',
           });
           if (!name) return;

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -366,6 +366,23 @@ export namespace flow.release {
     }
   }
 
+  /**
+   * Get the tag for a new release branch
+   */
+  export async function guess_new_version() {
+    const tag = git.TagRef.fromName("_start_new_release");
+    const tag_prefix = await tagPrefix() || '';
+    let version_tag = await tag.latest();
+    version_tag = version_tag.replace(tag_prefix, '');
+    if (version_tag.match(/^\d+\.\d+\.\d+$/)) {
+      let version_numbers = version_tag.split('.');
+      version_numbers[1] = String(Number(version_numbers[1]) + 1);
+      version_numbers[2] = "0";
+      version_tag = version_numbers.join('.');
+    }
+    return version_tag;
+  }
+
   export async function start(name: string) {
     await requireFlowEnabled();
     const current_release = await release.current();
@@ -528,6 +545,22 @@ export namespace flow.hotfix {
       throw throwNotInitializedError();
     }
     return branches.find(br => br.name.startsWith(prefix));
+  }
+
+  /**
+   * Get the tag for a new hotfix branch
+   */
+  export async function guess_new_version() {
+    const tag = git.TagRef.fromName("_start_new_hotfix");
+    const tag_prefix = await tagPrefix() || '';
+    let version_tag = await tag.latest();
+    version_tag = version_tag.replace(tag_prefix, '');
+    if (version_tag.match(/^\d+\.\d+\.\d+$/)) {
+      let version_numbers = version_tag.split('.');
+      version_numbers[2] = String(Number(version_numbers[2]) + 1);
+      version_tag = version_numbers.join('.');
+    }
+    return version_tag;
   }
 
   export async function start(name: string) {

--- a/src/flow.ts
+++ b/src/flow.ts
@@ -372,7 +372,7 @@ export namespace flow.release {
   export async function guess_new_version() {
     const tag = git.TagRef.fromName("_start_new_release");
     const tag_prefix = await tagPrefix() || '';
-    let version_tag = await tag.latest();
+    let version_tag = await tag.latest() || '0.0.0';
     version_tag = version_tag.replace(tag_prefix, '');
     if (version_tag.match(/^\d+\.\d+\.\d+$/)) {
       let version_numbers = version_tag.split('.');
@@ -553,7 +553,7 @@ export namespace flow.hotfix {
   export async function guess_new_version() {
     const tag = git.TagRef.fromName("_start_new_hotfix");
     const tag_prefix = await tagPrefix() || '';
-    let version_tag = await tag.latest();
+    let version_tag = await tag.latest() || '0.0.0';
     version_tag = version_tag.replace(tag_prefix, '');
     if (version_tag.match(/^\d+\.\d+\.\d+$/)) {
       let version_numbers = version_tag.split('.');

--- a/src/git.ts
+++ b/src/git.ts
@@ -197,6 +197,17 @@ export namespace git {
     }
 
     /**
+     * Get latest tag
+     */
+    public async latest(): Promise<string> {
+      const latest_tagged_commit = await cmd.executeRequired(
+        info.path, ['rev-list', '--tags', '--max-count=1']);
+      const result = await cmd.executeRequired(
+        info.path, ['describe', '--tags', latest_tagged_commit.stdout.trim()]);
+      return result.stdout.trim();
+    }
+
+    /**
      * Check if the tag exists
      */
     public async exists(): Promise<boolean> {

--- a/src/git.ts
+++ b/src/git.ts
@@ -200,11 +200,18 @@ export namespace git {
      * Get latest tag
      */
     public async latest(): Promise<string> {
-      const latest_tagged_commit = await cmd.executeRequired(
-        info.path, ['rev-list', '--tags', '--max-count=1']);
-      const result = await cmd.executeRequired(
-        info.path, ['describe', '--tags', latest_tagged_commit.stdout.trim()]);
-      return result.stdout.trim();
+      let last_tag = '';
+      const a_tag_exists = await cmd.executeRequired(
+        info.path, ['tag', '-l']);
+      if (a_tag_exists.stdout.trim()) {
+        const latest_tagged_commit = await cmd.executeRequired(
+          info.path, ['rev-list', '--tags', '--max-count=1']);
+        const result = await cmd.executeRequired(
+          info.path,
+          ['describe', '--tags', latest_tagged_commit.stdout.trim()]);
+        last_tag = result.stdout.trim();
+      }
+      return last_tag;
     }
 
     /**


### PR DESCRIPTION
If you are using the "Semantic Versioning" scheme (http://semver.org/) these changes try to guess the next version you probably want to use for your hotfix or release.

This is done by getting the latest git tag for all branches. This tag gets the "tagPrefix()" stripped off and is then used to build the new version number. For releases the MINOR number is increased and the PATCH number is set to zero, for hotfixes simply the PATCH number is increased.

This new version number is then put as a default "value" and as the "placeHolder" into the InputBox for the release or hotfix name.